### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/documentation/website/siteConfig.js
+++ b/documentation/website/siteConfig.js
@@ -32,6 +32,10 @@ const url = [
 ]
 
 const siteConfig = {
+    algolia: {
+    	apiKey: '84a612c2b93d457087aff69f653514e1',
+    	indexName: 'microkubes',
+    },
 	title: 'Pankod', // Title for your website.
 	headerTitle:'next-boilerplate',
 	tagline: 'Performance oriented Next.js application boilerplate with Redux, Typescript, Express.js, Sass and Project CLI.',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.