### PR TITLE
No Circular Deps & No Redundant Modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
         "react/jsx-indent": [2, 4, { "checkAttributes": false }],
         "react/jsx-indent-props": [2, 4],
         "import/prefer-default-export": "off",
-        "import/no-cycle": "off",
+        "import/no-cycle": "error",
         "no-multi-assign": "off"
     },
     "settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8996,7 +8996,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -12110,7 +12111,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -23278,7 +23280,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },

--- a/src/Components/Basic/Button/Button.d.ts
+++ b/src/Components/Basic/Button/Button.d.ts
@@ -1,10 +1,8 @@
 declare namespace IButton {
-    export interface IProps {
+    interface IProps {
         children?: React.ReactNode;
         className?: string;
         onClick?: (event: MouseEvent<HTMLDivElement, MouseEvent>) => void;
         disabled?: boolean;
     }
 }
-
-export { IButton };

--- a/src/Components/Basic/Button/index.tsx
+++ b/src/Components/Basic/Button/index.tsx
@@ -3,10 +3,6 @@ import React from "react";
 import styled from "styled-components";
 // #endregion Global Imports
 
-// #region Local Imports
-import { IButton } from "./Button";
-// #endregion Local Imports
-
 const Container = styled.div<IButton.IProps>`
     cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
     color: ${({ theme }) => theme.colors.primary};

--- a/src/Components/Basic/Button/index.tsx
+++ b/src/Components/Basic/Button/index.tsx
@@ -8,6 +8,6 @@ const Container = styled.div<IButton.IProps>`
     color: ${({ theme }) => theme.colors.primary};
 `;
 
-export const Button: React.FunctionComponent<IButton.IProps> = props => {
-    return <Container {...props} />;
-};
+export const Button: React.FC<IButton.IProps> = props => (
+    <Container {...props} />
+);

--- a/src/Components/Footer/Footer.d.ts
+++ b/src/Components/Footer/Footer.d.ts
@@ -1,5 +1,3 @@
 declare namespace IFooter {
-    export interface IProps {}
+    interface IProps {}
 }
-
-export { IFooter };

--- a/src/Components/Footer/index.tsx
+++ b/src/Components/Footer/index.tsx
@@ -2,12 +2,6 @@
 import * as React from "react";
 // #endregion Global Imports
 
-// #region Local Imports
-import { IFooter } from "./Footer";
-// #endregion Local Imports
-
-const Footer: React.FunctionComponent<IFooter.IProps> = (): JSX.Element => {
+export const Footer: React.FC<IFooter.IProps> = (): JSX.Element => {
     return <div className="footer">Footer</div>;
 };
-
-export { Footer };

--- a/src/Components/Heading/Heading.d.ts
+++ b/src/Components/Heading/Heading.d.ts
@@ -1,7 +1,5 @@
 declare namespace IHeading {
-    export interface IProps {
+    interface IProps {
         text: string;
     }
 }
-
-export { IHeading };

--- a/src/Components/Heading/index.tsx
+++ b/src/Components/Heading/index.tsx
@@ -6,13 +6,7 @@ import * as React from "react";
 import "./style.scss";
 // #endregion Local Imports
 
-// #region Interface Imports
-import { IHeading } from "./Heading";
-// #endregion Interface Imports
-
-const Heading: React.FunctionComponent<IHeading.IProps> = (
-    props
-): JSX.Element => {
+export const Heading: React.FC<IHeading.IProps> = (props): JSX.Element => {
     const { text } = props;
 
     return (
@@ -22,5 +16,3 @@ const Heading: React.FunctionComponent<IHeading.IProps> = (
         </div>
     );
 };
-
-export { Heading };

--- a/src/Components/Layout/index.tsx
+++ b/src/Components/Layout/index.tsx
@@ -2,10 +2,6 @@ import * as React from "react";
 
 import { LayoutProps } from "./Layout";
 
-const Layout: React.FunctionComponent<LayoutProps> = ({
-    children,
-}): JSX.Element => {
-    return <div className="layout">{children}</div>;
-};
-
-export { Layout };
+export const Layout: React.FC<LayoutProps> = ({ children }): JSX.Element => (
+    <div className="layout">{children}</div>
+);

--- a/src/Components/LocaleButton/LocaleButton.d.ts
+++ b/src/Components/LocaleButton/LocaleButton.d.ts
@@ -1,9 +1,7 @@
 declare namespace ILocaleButton {
-    export interface IProps {
+    interface IProps {
         lang: string;
         onClick: (param: any) => void;
         isActive: boolean;
     }
 }
-
-export { ILocaleButton };

--- a/src/Components/LocaleButton/index.tsx
+++ b/src/Components/LocaleButton/index.tsx
@@ -1,7 +1,5 @@
-import React from "react";
+import * as React from "react";
 import styled from "styled-components";
-
-import { ILocaleButton } from "./LocaleButton";
 
 import { Button } from "../Basic";
 
@@ -9,7 +7,7 @@ const Container = styled(Button)<{ isActive: boolean }>`
     color: ${({ isActive }) => (isActive ? "#2c3e50" : "inherit")};
 `;
 
-export const LocaleButton: React.FunctionComponent<ILocaleButton.IProps> = ({
+export const LocaleButton: React.FC<ILocaleButton.IProps> = ({
     lang,
     isActive,
     onClick,

--- a/src/Components/Navbar/Navbar.d.ts
+++ b/src/Components/Navbar/Navbar.d.ts
@@ -1,5 +1,3 @@
 declare namespace INavbar {
-    export interface IProps {}
+    interface IProps {}
 }
-
-export { INavbar };

--- a/src/Components/Navbar/index.tsx
+++ b/src/Components/Navbar/index.tsx
@@ -1,9 +1,5 @@
 import * as React from "react";
 
-import { INavbar } from "./Navbar";
-
-const Navbar: React.FunctionComponent<INavbar.IProps> = (): JSX.Element => {
+export const Navbar: React.FC<INavbar.IProps> = (): JSX.Element => {
     return <div className="navbar">Navbar</div>;
 };
-
-export { Navbar };

--- a/src/Definitions/Styled/theme.ts
+++ b/src/Definitions/Styled/theme.ts
@@ -2,10 +2,8 @@
 import { DefaultTheme } from "styled-components";
 // #endregion Global Imports
 
-const theme: DefaultTheme = {
+export const theme: DefaultTheme = {
     colors: {
         primary: "#2c3e50",
     },
 };
-
-export { theme };

--- a/src/Interfaces/Pages/Error.d.ts
+++ b/src/Interfaces/Pages/Error.d.ts
@@ -2,14 +2,12 @@
 import { WithTranslation } from "next-i18next";
 // #endregion Global Imports
 
-declare namespace IErrorPage {
-    export interface IProps extends WithTranslation {
+export namespace IErrorPage {
+    interface IProps extends WithTranslation {
         statusCode?: number;
     }
 
-    export interface InitialProps {
+    interface InitialProps {
         namespacesRequired: string[];
     }
 }
-
-export { IErrorPage };

--- a/src/Interfaces/Pages/Home.d.ts
+++ b/src/Interfaces/Pages/Home.d.ts
@@ -2,14 +2,14 @@
 import { WithTranslation } from "next-i18next";
 // #endregion Global Imports
 
-declare namespace IHomePage {
-    export interface IProps extends WithTranslation {}
+export namespace IHomePage {
+    interface IProps extends WithTranslation {}
 
-    export interface InitialProps {
+    interface InitialProps {
         namespacesRequired: string[];
     }
 
-    export interface IStateProps {
+    interface IStateProps {
         home: {
             version: number;
         };
@@ -19,17 +19,14 @@ declare namespace IHomePage {
     }
 
     namespace Actions {
-        export interface IMapPayload {}
+        interface IMapPayload {}
 
-        export interface IMapResponse {}
+        interface IMapResponse {}
 
-        export interface IGetApodPayload extends PlanetaryModel.GetApodPayload {
+        interface IGetApodPayload extends Planetary.GetApodPayload {
             params: {};
         }
 
-        export interface IGetApodResponse
-            extends PlanetaryModel.GetApodResponse {}
+        interface IGetApodResponse extends Planetary.GetApodResponse {}
     }
 }
-
-export { IHomePage };

--- a/src/Interfaces/index.ts
+++ b/src/Interfaces/index.ts
@@ -8,10 +8,3 @@ export * from "@Interfaces/Pages/Error";
 export * from "@Redux/IAction";
 export * from "@Redux/IStore";
 // #endregion Redux Interfaces
-
-// #region Service Interfaces
-export * from "@Services/API/Http/Http";
-export * from "@Services/API/Planetary/ApodPayload";
-export * from "@Services/API/Planetary/ApodResponse";
-export * from "@Services/API/Planetary/Planetary";
-// #endregion Service Interfaces

--- a/src/Redux/IStore.d.ts
+++ b/src/Redux/IStore.d.ts
@@ -1,5 +1,5 @@
 // #region Interface Imports
-import { IHomePage } from "@Interfaces";
+import { IHomePage } from "@Interfaces/Pages/Home";
 // #endregion Interface Imports
 
 export interface IStore {

--- a/src/Services/API/Http/Http.d.ts
+++ b/src/Services/API/Http/Http.d.ts
@@ -1,11 +1,9 @@
 declare namespace HttpModel {
-    export interface IRequestPayload {
-        [key: string]: {};
+    interface Dictionary {
+        [key: string]: any;
     }
 
-    export interface IRequestQueryPayload {
-        [key: string]: {};
-    }
+    interface IRequestPayload extends Dictionary {}
+
+    interface IRequestQueryPayload extends Dictionary {}
 }
-
-export { HttpModel };

--- a/src/Services/API/Http/index.ts
+++ b/src/Services/API/Http/index.ts
@@ -4,10 +4,6 @@ import getConfig from "next/config";
 import { stringify } from "query-string";
 // #endregion Global Imports
 
-// #region Interface Imports
-import { HttpModel } from "@Interfaces";
-// #endregion Interface Imports
-
 const {
     publicRuntimeConfig: { API_KEY, API_URL },
 } = getConfig();

--- a/src/Services/API/Planetary/ApodPayload.d.ts
+++ b/src/Services/API/Planetary/ApodPayload.d.ts
@@ -1,4 +1,0 @@
-export interface ApodPayload {
-    [key: string]: string;
-    hd?: boolean;
-}

--- a/src/Services/API/Planetary/ApodResponse.d.ts
+++ b/src/Services/API/Planetary/ApodResponse.d.ts
@@ -1,9 +1,0 @@
-export interface ApodResponse {
-    copyright: string;
-    date: string;
-    explanation: string;
-    hdurl: string;
-    service_version: string;
-    title: string;
-    url: string;
-}

--- a/src/Services/API/Planetary/Planetary.d.ts
+++ b/src/Services/API/Planetary/Planetary.d.ts
@@ -1,13 +1,22 @@
-// #region Interface Imports
-import { ApodPayload, ApodResponse } from "@Interfaces";
-// #endregion Interface Imports
+declare namespace Planetary {
+    interface ApodPayload {
+        hd?: boolean;
+        [key: string]: any;
+    }
 
-declare namespace PlanetaryModel {
-    export interface GetApodPayload {
+    interface ApodResponse {
+        copyright: string;
+        date: string;
+        explanation: string;
+        hdurl: string;
+        service_version: string;
+        title: string;
+        url: string;
+    }
+
+    interface GetApodPayload {
         params: ApodPayload;
     }
 
-    export interface GetApodResponse extends ApodResponse {}
+    interface GetApodResponse extends ApodResponse {}
 }
-
-export { PlanetaryModel };

--- a/src/Services/API/Planetary/index.ts
+++ b/src/Services/API/Planetary/index.ts
@@ -1,19 +1,15 @@
 // #region Local Imports
-import { Http } from "@Services";
+import { Http } from "@Services/API/Http";
 // #endregion Local Imports
-
-// #region Interface Imports
-import { PlanetaryModel } from "@Interfaces";
-// #endregion Interface Imports
 
 export const PlanetaryService = {
     GetPlanetImage: async (
-        payload: PlanetaryModel.GetApodPayload
-    ): Promise<PlanetaryModel.GetApodResponse> => {
-        let response: PlanetaryModel.GetApodResponse;
+        payload: Planetary.GetApodPayload
+    ): Promise<Planetary.GetApodResponse> => {
+        let response: Planetary.GetApodResponse;
 
         try {
-            response = await Http.Request<PlanetaryModel.GetApodResponse>(
+            response = await Http.Request<Planetary.GetApodResponse>(
                 "GET",
                 "/planetary/apod",
                 payload.params


### PR DESCRIPTION
# No Circular Deps & No Redundant Modules

- [x] Resolves #81 
- [x] Resolves #88 

- Switched usage `FunctionComponent` type to `FC`
- Switched to direct `return` if possible
- Switched to direct `export` if possible

- Types **without imports** turned into *global*
- Discarded redundant import statements
- Resolved circular-deps by importing explicitly